### PR TITLE
use global config for common constants

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,6 @@
+// define and export all your common constants here
+module.exports = {
+  SQS_QUEUE: process.env.sqsQueue,
+  S3_BUCKET: process.env.s3Bucket,
+  RELEASE: process.env.release
+};

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,24 +1,20 @@
-'use strict';
+"use strict";
 
 // Load Required libraries
-const AWS   = require('aws-sdk');
-const async = require('async');
+const AWS = require("aws-sdk");
+const async = require("async");
+const config = require("./config");
 
 // Set the region... is this really needed?
-AWS.config.update({region: process.env.region});
+AWS.config.update({ region: process.env.region });
 
 // Create the sqs service opbject
-var sqs    = new AWS.SQS({apiVersion: '2012-11-05'});
+var sqs = new AWS.SQS({ apiVersion: "2012-11-05" });
 var lambda = new AWS.Lambda();
-
-// Read the queue and s3 info from the env
-var sqsQueue = process.env.sqsQueue;
-var s3Bucket = process.env.s3Bucket;
-var release  = process.env.release;
 
 function receiveMessages(callback) {
   var params = {
-    QueueUrl: sqsQueue,
+    QueueUrl: config.SQS_QUEUE,
     MaxNumberOfMessages: 100
   };
   sqs.receiveMessage(params, function(err, data) {
@@ -33,8 +29,8 @@ function receiveMessages(callback) {
 
 function invokeWorkerLambda(task, callback) {
   var params = {
-    FunctionName: 'jenkins-plugins-rpm-package',
-    InvocationType: 'Event',
+    FunctionName: "jenkins-plugins-rpm-package",
+    InvocationType: "Event",
     Payload: JSON.stringify(task)
   };
 
@@ -66,12 +62,12 @@ function handleSQSMessages(context, callback) {
           if (context.getRemainingTimeInMillis() > 20000) {
             handleSQSMessages(context, callback);
           } else {
-            callback(null, 'PAUSE');
+            callback(null, "PAUSE");
           }
         }
       });
     } else {
-      callback(null, 'DONE');
+      callback(null, "DONE");
     }
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,9 @@
-'use strict';
+"use strict";
 
-const AWS = require('aws-sdk');
+const AWS = require("aws-sdk");
 
 // Set the region... is this really needed?
-AWS.config.update({region: process.env.region});
-
-// Read the queue and s3 info from the env.  These are set as env variables
-// on the lambdas by the terraform script that creates everything in aws.
-var sqsQueue = process.env.sqsQueue;
-var s3Bucket = process.env.s3Bucket;
-var release  = process.env.release;
+AWS.config.update({ region: process.env.region });
 
 // Is the version needed?
-var sqs = new AWS.SQS({apiVersion: '2012-11-05'});
+var sqs = new AWS.SQS({ apiVersion: "2012-11-05" });

--- a/src/package.js
+++ b/src/package.js
@@ -3,6 +3,8 @@
 // Load Required libraries
 const https = require('https');
 const AWS   = require('aws-sdk');
+// import the config module
+const config = require('./config');
 
 // Set the region... is this really needed?
 AWS.config.update({region: process.env.region});
@@ -11,15 +13,11 @@ AWS.config.update({region: process.env.region});
 var sqs = new AWS.SQS({apiVersion: '2012-11-05'});
 var s3  = new AWS.S3();
 
-// Read the queue and s3 info from the env
-var sqsQueue = process.env.sqsQueue;
-var s3Bucket = process.env.s3Bucket;
-var release  = process.env.release;
-
 function deleteMessage(receiptHandle, cb) {
   sqs.deleteMessage({
     ReceiptHandle: receiptHandle,
-    QueueUrl: sqsQueue
+    // reference the SQS_QUEUE param on the imported config object
+    QueueUrl: config.SQS_QUEUE
   }, cb);
 }
 
@@ -30,7 +28,7 @@ function work(task, cb) {
   console.log(pName);
 
   let params = {
-    Bucket: s3Bucket,
+    Bucket: config.S3_BUCKET,
     Key: '/rpm/' + pName + '.rpm'
   };
 


### PR DESCRIPTION
First pass for code cleanup.  A common pattern I've seen used for accessing env vars or other constants that don't change during runtime is to define a config module which exports an object.  That object will contain key value pairs of the data you'd want to access.  Then, in any .js file that needs to reference it, you'd import the configuration object `const config = require('./config')` at the top of your file, and when you need to access a property, you can do something like ` { bucket: config.S3_BUCKET}`.  

A few other notes: I'd move away from the `var` keyword and use `let` and `const` unless absolutely necessary, as that's where modern javascript is going (you can worry less about inadvertent variable mutations that way).  Also, might want to consider using Promises instead of callbacks (if possible) to avoid the potential for callback hell.  Promise support has been available since node 6 (https://node.green/).  